### PR TITLE
Bugfix: icon is scaled to 0 on dark mode with only light icon

### DIFF
--- a/src/app/blog/[slug]/page.tsx
+++ b/src/app/blog/[slug]/page.tsx
@@ -101,7 +101,7 @@ const BlogPage = async ({ params: { slug } }: { params: { slug: string } }) => {
               <TooltipWrapper key={index} text={tech.name} asChild>
                 <ExternalLink href={tech.href} variant='outline' size='icon' className='relative'>
                   <Suspense fallback={<Skeleton className='relative h-full w-full' />}>
-                    {tech?.icon?.dark && tech?.icon?.light ? (
+                    {(tech?.icon?.dark && tech?.icon?.light) ? (
                       <>
                         <Image
                           src={urlFor(tech.icon.light).url()}
@@ -120,13 +120,13 @@ const BlogPage = async ({ params: { slug } }: { params: { slug: string } }) => {
                       </>
                     ) : (
                       <>
-                        {tech.icon?.dark || tech.icon?.light ? (
+                        {(tech.icon?.dark || tech.icon?.light) ? (
                           <Image
                             src={tech.icon.dark ? urlFor(tech.icon.dark).url() : urlFor(tech.icon.light).url()}
                             alt='/images/dark.svg'
                             width={16}
                             height={16}
-                            className='absolute h-full w-full scale-100 transition-all dark:scale-0'
+                            className='absolute h-full w-full scale-100 transition-all'
                           />
 
                         ) : (

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -128,7 +128,7 @@ const RenderSkills = async () => {
         <TooltipWrapper key={key} text={skill.name} asChild>
           <ExternalLink href={skill.href} size='icon' variant='outline' className='relative'>
             <Suspense fallback={<Skeleton className='relative h-full w-full' />}>
-              {skill?.icon?.dark && skill?.icon?.light ? (
+              {(skill?.icon?.dark && skill?.icon?.light) ? (
                 <>
                   <Image
                     src={urlFor(skill.icon.light).url()}
@@ -147,13 +147,13 @@ const RenderSkills = async () => {
                 </>
               ) : (
                 <>
-                  {skill.icon?.dark || skill.icon?.light ? (
+                  {(skill.icon?.dark || skill.icon?.light) ? (
                     <Image
                       src={skill.icon.dark ? urlFor(skill.icon.dark).url() : urlFor(skill.icon.light).url()}
                       alt='/images/dark.svg'
                       width={16}
                       height={16}
-                      className='absolute h-6 w-6 scale-100 transition-all dark:scale-0'
+                      className='absolute h-6 w-6 scale-100 transition-all'
                     />
 
                   ) : (

--- a/src/app/projects/[slug]/page.tsx
+++ b/src/app/projects/[slug]/page.tsx
@@ -138,7 +138,7 @@ const ProjectPage = async ({ params: { slug } }: { params: { slug: string } }) =
               <TooltipWrapper key={index} text={tech.name} asChild>
                 <ExternalLink href={tech.href} variant='outline' size='icon' className='relative'>
                   <Suspense fallback={<Skeleton className='relative h-full w-full' />}>
-                    {tech?.icon?.dark && tech?.icon?.light ? (
+                    {(tech?.icon?.dark && tech?.icon?.light) ? (
                       <>
                         <Image
                           src={urlFor(tech.icon.light).url()}
@@ -157,13 +157,13 @@ const ProjectPage = async ({ params: { slug } }: { params: { slug: string } }) =
                       </>
                     ) : (
                       <>
-                        {tech.icon?.dark || tech.icon?.light ? (
+                        {(tech.icon?.dark || tech.icon?.light) ? (
                           <Image
                             src={tech.icon.dark ? urlFor(tech.icon.dark).url() : urlFor(tech.icon.light).url()}
                             alt='/images/dark.svg'
                             width={16}
                             height={16}
-                            className='absolute h-6 w-6 scale-100 transition-all dark:scale-0'
+                            className='absolute h-6 w-6 scale-100 transition-all'
                           />
 
                         ) : (


### PR DESCRIPTION
<!--
  For Work In Progress Pull Requests, please use the Draft PR feature,
  see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

  For a timely review/response, please avoid force-pushing additional
  commits if your PR already received reviews or comments.

  Before submitting a Pull Request, please ensure you've done the following:
  - 📖 Read the our Code of Conduct: https://github.com/caffeine-addictt/portfolio/blob/main/CODE_OF_CONDUCT.md
  - 👷‍♀️ Create small PRs. In most cases this will be possible.
  - ✅ Provide tests for your changes.
  - 📝 Use descriptive commit messages.
  - 📗 Update any related documentation and include any relevant screenshots.
-->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Breaking Change
- [ ] Documentation Update

## Description
When skill only has a light or dark theme icon, it is scaled to 0 on dark mode

## Checklist
<!---
Go over all the following points, and put an `x` in all the boxes that apply.
If you're unsure about any of these, don't hesitate to ask. We're here to help!
-->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
