### PR TITLE
fix: Decoding invalid JSON

### DIFF
--- a/src/lib/sanity/client.ts
+++ b/src/lib/sanity/client.ts
@@ -49,11 +49,16 @@ const generateTechQuery = (
 };
 
 export const countProjects = cache(
-  async (): Promise<number> =>
-    await client.fetch(`count(*[_type == "projects"])`),
+  (): Promise<number> =>
+    client
+      .fetch(`{ 'count': count(*[_type == "projects"]) }`)
+      .then((res: { count: number }) => res.count),
 );
 export const countBlogs = cache(
-  async (): Promise<number> => await client.fetch(`count(*[_type == "blogs"])`),
+  (): Promise<number> =>
+    client
+      .fetch(`{ 'count': count(*[_type == "blogs"]) }`)
+      .then((res: { count: number }) => res.count),
 );
 
 export interface ProjectQuery {


### PR DESCRIPTION
This patch fixes the invalid JSON decoding from the query. This is because we get JSON string 'X' where X is an integer. This is not valid JSON.

We can fix this by returning a valid JSON object { count: number } and return response.count. This way, only the query and return has to change and nothing else.