### PR TITLE
ci: Only lint and test on PRs

### DIFF
--- a/.github/workflows/linting.yml
+++ b/.github/workflows/linting.yml
@@ -2,6 +2,8 @@ name: Linting
 
 on:
   push:
+    branches:
+      - main
   pull_request:
   workflow_dispatch:
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -2,6 +2,8 @@ name: 'Testing'
 
 on:
   push:
+    branches:
+      - main
   pull_request:
   workflow_dispatch:
 


### PR DESCRIPTION
Let's not run linting and tests on every push to non-main
